### PR TITLE
Improve process object by providing fields for disk usage, current working directory, elapsed time, is file on disk and actual environment variables count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ Thankyou! -->
     9. Added `cwd` as a `string_t`.
     10. Added `elapsed_time` as a `timespan`.
     11. Added `is_on_disk` as a `boolean_t`.
-    12. Added `env_vars_actual_count` as a `integer_t`.
+    12. Added `env_vars_actual_count` as an `integer_t`.
 
 * #### Objects
     1. Added `environment_variable` object. #1172

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,13 @@ Thankyou! -->
     4. Added `forward_addr` as an `email_t`. #1179
     5. Added `related_cves`, `related_cwes` as arrays of `cve`, `cwe` respectively. #1176
     6. Added `exploit_last_seen_time` as a `timestamp_t`. #1176
+    7. Added `bytes_read_disk` as a `long_t`.
+    8. Added `bytes_written_disk` as a `long_t`.
+    9. Added `cwd` as a `string_t`.
+    10. Added `elapsed_time` as a `timespan`.
+    11. Added `is_on_disk` as a `boolean_t`.
+    12. Added `env_vars_actual_count` as a `integer_t`.
+
 * #### Objects
     1. Added `environment_variable` object. #1172
     2. Added `advisory` object. #1176
@@ -70,6 +77,12 @@ Thankyou! -->
     7. Added `src_url` to the `cvss` object. #1176
     8. Added `advisory`, `exploit_last_seen_time` to the `vulnerability` object. #1176
     9. Added `related_cwes` to the `cve` object. #1176
+    10. Added `bytes_read_disk` to the `process` object.
+    11. Added `bytes_written_disk` to the `process` object.
+    12. Added `cwd` to the `process` object.
+    13. Added `elapsed_time` to the `process` object.
+    14. Added `is_on_disk` to the `process` object.
+    15. Added `env_vars_actual_count` to the `process` object.
 
 ### Bugfixes
 1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,12 +77,7 @@ Thankyou! -->
     7. Added `src_url` to the `cvss` object. #1176
     8. Added `advisory`, `exploit_last_seen_time` to the `vulnerability` object. #1176
     9. Added `related_cwes` to the `cve` object. #1176
-    10. Added `bytes_read_disk` to the `process` object.
-    11. Added `bytes_written_disk` to the `process` object.
-    12. Added `cwd` to the `process` object.
-    13. Added `elapsed_time` to the `process` object.
-    14. Added `is_on_disk` to the `process` object.
-    15. Added `env_vars_actual_count` to the `process` object.
+    10. Added `bytes_read_disk`, `bytes_written_disk`, `cwd`, `elapsed_time`, `env_vars_actual_count` and `is_on_disk`  to the `process` object.
 
 ### Bugfixes
 1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180

--- a/dictionary.json
+++ b/dictionary.json
@@ -450,6 +450,16 @@
       "description": "The number of bytes sent from the source to the destination.",
       "type": "long_t"
     },
+    "bytes_read_disk": {
+      "caption": "Bytes Read from Disk",
+      "description": "The number of bytes read from disk.",
+      "type": "long_t"
+    },
+    "bytes_written_disk": {
+      "caption": "Bytes Written to Disk",
+      "description": "The number of bytes written to disk.",
+      "type": "long_t"
+    },
     "capabilities": {
       "caption": "Capabilities",
       "description": "A list of RDP capabilities.",
@@ -1210,6 +1220,11 @@
       "type": "cvss",
       "is_array": true
     },
+    "cwd": {
+      "caption": "Current Working Directory",
+      "description": "The current working directory of a process. If the current working directory is unavailable or missing, the empty string <code>''</code> is to be used.",
+      "type": "string_t"
+    },
     "cwe": {
       "caption": "CWE",
       "description": "The CWE object represents a weakness in a software system that can be exploited by a threat actor to perform an attack. The CWE object is based on the <a target='_blank' href='https://cwe.mitre.org/'>Common Weakness Enumeration (CWE)</a> catalog.",
@@ -1764,6 +1779,11 @@
       "caption": "OS Edition",
       "description": "The operating system edition. For example: <code>Professional</code>.",
       "type": "string_t"
+    },
+    "elapsed_time": {
+      "caption": "Elapsed Time",
+      "description": "The elapsed time span of an activity.",
+      "type": "timespan"
     },
     "email": {
       "caption": "Email",
@@ -2476,6 +2496,11 @@
     "is_new_logon": {
       "caption": "New Logon",
       "description": "Indicates logon is from a device not seen before or a first time account logon.",
+      "type": "boolean_t"
+    },
+    "is_on_disk": {
+      "caption": "On Disk",
+      "description": "The indication of whether the item exists on disk.",
       "type": "boolean_t"
     },
     "is_on_premises": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -1854,6 +1854,11 @@
       "type": "environment_variable",
       "is_array": true
     },
+    "env_vars_actual_count": {
+      "caption": "Environment Variables Actual Count",
+      "description": "The actual count of environment variables.",
+      "type": "integer_t"
+    },
     "epoch": {
       "caption": "Epoch",
       "description": "The software package epoch. Epoch is a way to define weighted dependencies based on version numbers.",

--- a/objects/process.json
+++ b/objects/process.json
@@ -30,7 +30,7 @@
       "requirement": "recommended"
     },
     "elapsed_time": {
-      "description": "The amount of time that the process has been running",
+      "description": "The amount of time that the process has been running.",
       "requirement": "optional"
     },
     "environment_variables": {

--- a/objects/process.json
+++ b/objects/process.json
@@ -11,12 +11,27 @@
     "$include": [
       "profiles/container.json"
     ],
+    "bytes_read_disk": {
+      "description": "The number of bytes read from disk by this process.",
+      "requirement": "optional"
+    },
+    "bytes_written_disk": {
+      "description": "The number of bytes written to disk by this process.",
+      "requirement": "optional"
+    },
     "cmd_line": {
       "requirement": "recommended"
+    },
+    "cwd": {
+      "requirement": "optional"
     },
     "created_time": {
       "description": "The time when the process was created/started.",
       "requirement": "recommended"
+    },
+    "elapsed_time": {
+      "description": "The amount of time that the process has been running",
+      "requirement": "optional"
     },
     "environment_variables": {
       "description": "Environment variables associated with the process.",
@@ -30,6 +45,10 @@
       "requirement": "optional"
     },
     "integrity_id": {
+      "requirement": "optional"
+    },
+    "is_on_disk": {
+      "description": "The indication of whether the process file exists on disk.",
       "requirement": "optional"
     },
     "lineage": {

--- a/objects/process.json
+++ b/objects/process.json
@@ -37,6 +37,10 @@
       "description": "Environment variables associated with the process.",
       "requirement": "optional"
     },
+    "env_vars_actual_count": {
+      "description": "The actual count of environment variables associated with the process. A count larger than the number of variables specified in the <code>environment_variables</code> array indicates the process environment had more variables than had been recorded.",
+      "requirement": "optional"
+    },
     "file": {
       "description": "The process file object.",
       "requirement": "recommended"


### PR DESCRIPTION
#### Related Issue: 
N/A

#### Description of changes:
This improve the `process` object by adding these fields:

| Caption | Name | Rationale 
| - | - | - 
| Bytes Read/Written from/to Disk | `bytes_read_disk`, `bytes_written_disk` |  To identify exfiltration, ransomware
| Current Working Directory | `cwd` | Assists in interpreting `cmd_line`
| Elapsed Time  |  `elapsed_time` | To identify processes masquerading as long-running processes
| On Disk | `is_on_disk` | To identify processes that delete its own files for defence evasion
| Environment Variables Actual Count | `env_vars_actual_count` | Indicates when only some variables were captured, a UI can then display "+ 10 other variables not captured" or similar) 
