### PR TITLE
Add current_working_directory to the process object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Thankyou! -->
     5. Added `related_cves`, `related_cwes` as arrays of `cve`, `cwe` respectively. #1176
     6. Added `exploit_last_seen_time` as a `timestamp_t`. #1176
     7. Added `is_alert` as a `boolean_t`, #1179
+    8. Added `current_working_directory` as a `string_t`. #1190
 
 * #### Objects
     1. Added `environment_variable` object. #1172
@@ -75,6 +76,7 @@ Thankyou! -->
     8. Added `advisory`, `exploit_last_seen_time` to the `vulnerability` object. #1176
     9. Added `related_cwes` to the `cve` object. #1176
     10. Added `vendor_name` and `model` to `device` object.
+    11. Added `current_working_directory` to `process` object. #1190
 
 ### Bugfixes
 1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180

--- a/dictionary.json
+++ b/dictionary.json
@@ -1184,6 +1184,11 @@
       "description": "Criticality of a resource/object in question",
       "type": "string_t"
     },
+    "current_working_directory": {
+      "caption": "Current Working Directory",
+      "description": "The current working directory of a process.",
+      "type": "string_t"
+    },
     "customer_uid": {
       "caption": "Customer UID",
       "description": "The unique customer identifier.",

--- a/objects/process.json
+++ b/objects/process.json
@@ -14,6 +14,9 @@
     "cmd_line": {
       "requirement": "recommended"
     },
+    "current_working_directory": {
+      "requirement": "optional"
+    },
     "created_time": {
       "description": "The time when the process was created/started.",
       "requirement": "recommended"


### PR DESCRIPTION
#### Related Issue: 
#1190

#### Description of changes:
Add optional `current_working_directory` field to the process object, with type `string_t`.

![add_cwd_screenshot](https://github.com/user-attachments/assets/f5adb2a9-6254-443f-ac5b-b8e8c5b5e34d)

