### PR TITLE
Modify Environment Variable object: Fix name or value truncated ambiguity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,17 +49,17 @@ Thankyou! -->
 * #### Dictionary Attributes
     1. Added `has_mfa` as a `boolean_t`. #1155
     2. Added `environment_variables` as an array of `environment_variable` object. #1172
-    3. Added `is_attribute_truncated` as a `boolean_t`. #1172
-    4. Added `forward_addr` as an `email_t`. #1179
-    5. Added `related_cves`, `related_cwes` as arrays of `cve`, `cwe` objects respectively. #1176
-    6. Added `exploit_last_seen_time` as a `timestamp_t`. #1176
-    7. Added `is_alert` as a `boolean_t`, #1179
-    8. Added `working_directory` as a `string_t`. #1195
-    9. Added `is_deleted` a `boolean_t`. #1196
-    10. Added `is_script_content_truncated` as a `boolean_t`. #1198
-    11. Added `body_length` as an `integer_t` #1200
-    12. Added `is_public` as a `boolean_t` #1208
-    13. Added `tags` as n array of `tag` object. #1207
+    3. Added `forward_addr` as an `email_t`. #1179
+    4. Added `related_cves`, `related_cwes` as arrays of `cve`, `cwe` objects respectively. #1176
+    5. Added `exploit_last_seen_time` as a `timestamp_t`. #1176
+    6. Added `is_alert` as a `boolean_t`, #1179
+    7. Added `working_directory` as a `string_t`. #1195
+    8. Added `is_deleted` a `boolean_t`. #1196
+    9. Added `is_script_content_truncated` as a `boolean_t`. #1198
+    10. Added `body_length` as an `integer_t` #1200
+    11. Added `is_public` as a `boolean_t` #1208
+    12. Added `tags` as n array of `tag` object. #1207
+    13. Added `is_name_truncated` and `is_value_truncated` as `boolean_t`s.
 * #### Objects
     1. Added `environment_variable` object. #1172
     2. Added `advisory` object. #1176
@@ -90,6 +90,7 @@ Thankyou! -->
     16. Added `body_length` to the `http_response` and `http_request` objects. #1200
     17. Added `is_public` to the `databucket` object. #1208
     18. Added `tags` to the `account`, `container`, `image`, `ldap_person`, `metadata`, `resource_details`, `service`, `web_resource` objects. #1207
+    19. Added `is_name_truncated` and `is_value_truncated` to the `environment_variable` object.
 
 
 ### Bugfixes

--- a/dictionary.json
+++ b/dictionary.json
@@ -2440,11 +2440,6 @@
       "description": "A determination if a policy, rule, or enforcement action was applied.",
       "type": "boolean_t"
     },
-    "is_attribute_truncated": {
-      "caption": "Attribute Truncated",
-      "description": "The indication of whether or not an attribute is truncated.",
-      "type": "boolean_t"
-    },
     "is_cleartext": {
       "caption": "Cleartext Credentials",
       "description": "Indicates whether the credentials were passed in clear text.<p><b>Note:</b> True if the credentials were passed in a clear text protocol such as FTP or TELNET, or if Windows detected that a user's logon password was passed to the authentication package in clear text.</p>",
@@ -2493,6 +2488,11 @@
     "is_mfa": {
       "caption": "Multi Factor Authentication",
       "description": "Indicates whether Multi Factor Authentication was used during authentication.",
+      "type": "boolean_t"
+    },
+    "is_name_truncated": {
+      "caption": "Is Name Truncated",
+      "description": "Indicates if the <code>name</code> attribute have been truncated.",
       "type": "boolean_t"
     },
     "is_new_logon": {
@@ -2563,6 +2563,11 @@
     "is_trusted": {
       "caption": "Trusted Device",
       "description": "The event occurred on a trusted device.",
+      "type": "boolean_t"
+    },
+    "is_value_truncated": {
+      "caption": "Is Value Truncated",
+      "description": "Indicates if the <code>value</code> attribute have been truncated.",
       "type": "boolean_t"
     },
     "is_vpn": {

--- a/objects/environment_variable.json
+++ b/objects/environment_variable.json
@@ -4,6 +4,12 @@
     "extends": "object",
     "name": "environment_variable",
     "attributes": {
+        "is_name_truncated": {
+            "requirement": "optional"
+        },
+        "is_value_truncated": {
+            "requirement": "optional"
+        },
         "name": {
             "description": "The name of the environment variable.",
             "requirement": "required"
@@ -11,10 +17,6 @@
         "value": {
             "description": "The value of the environment variable.",
             "requirement": "required"
-        },
-        "is_attribute_truncated": {
-            "description": "Whether the <code>name</code> or <code>value</code> of the environment variable has been truncated.",
-            "requirement": "optional"
         }
     }
 }


### PR DESCRIPTION
#### Related Issue: 

#### Description of changes:

Modifies the `environment_variable` object to replace the `is_attribute_truncated` field, which introduces ambiguity as to whether it was the environment variable name or value string, or both, that was truncated, with separate `is_name_truncated` and `is_value_truncated` fields.

![image](https://github.com/user-attachments/assets/d0495870-1d88-43a7-901c-a08a48ccb43a)
