### PR TITLE
Deprecate imei in favor of imeis to support more than one IMEI in device object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Thankyou! -->
     12. Added `is_public` as a `boolean_t` #1208
     13. Added `tags` as n array of `tag` object. #1207
     14. Added `community_uid` as a `string_t`. #1202
+    15. Added `imei_alts` as an array `string_t`.
 
 * #### Objects
     1. Added `environment_variable` object. #1172
@@ -92,6 +93,7 @@ Thankyou! -->
     16. Added `body_length` to the `http_response` and `http_request` objects. #1200
     17. Added `is_public` to the `databucket` object. #1208
     18. Added `tags` to the `account`, `container`, `image`, `ldap_person`, `metadata`, `resource_details`, `service`, `web_resource` objects. #1207
+    19. Added `imei_alts` to the `device` object.
 
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ Thankyou! -->
     12. Added `is_public` as a `boolean_t` #1208
     13. Added `tags` as n array of `tag` object. #1207
     14. Added `community_uid` as a `string_t`. #1202
-    15. Added `imei_alts` as an array `string_t`.
+    15. Added `imeis` as an array `string_t`.
 
 * #### Objects
     1. Added `environment_variable` object. #1172
@@ -93,7 +93,7 @@ Thankyou! -->
     16. Added `body_length` to the `http_response` and `http_request` objects. #1200
     17. Added `is_public` to the `databucket` object. #1208
     18. Added `tags` to the `account`, `container`, `image`, `ldap_person`, `metadata`, `resource_details`, `service`, `web_resource` objects. #1207
-    19. Added `imei_alts` to the `device` object.
+    19. Added `imeis` to the `device` object.
 
 
 ### Bugfixes
@@ -112,6 +112,7 @@ Thankyou! -->
 2. Deprecated `kb_article_list` in favor of `advisory` in the vulnerability object. #1176
 3. Deprecated `cwe` in favor of `related_cwes` in the `cve` object. #1176
 4. Deprecated `tag` in favor of `labels` or `tags` in `image` & `container` object. #1207
+5. Deprecated `imei` in favor of `imeis` in `device` object.
 
 ### Misc
 1. Added `user.uid` as an Observable type - `type_id: 31`. #1155

--- a/dictionary.json
+++ b/dictionary.json
@@ -2264,6 +2264,12 @@
       "description": "The International Mobile Station Equipment Identifier that is associated with the device.",
       "type": "string_t"
     },
+    "imei_alts": {
+      "caption": "Alternate IMEIs",
+      "description": "Alternate International Mobile Station Equipment Identifiers that are associated with the device, such as additional IMEIs for devices with more than one Subscriber Identity Module (SIM).",
+      "is_array": true,
+      "type": "string_t"
+    },
     "impact": {
       "caption": "Impact",
       "description": "The impact , normalized to the caption of the impact_id value. In the case of 'Other', it is defined by the event source.",

--- a/dictionary.json
+++ b/dictionary.json
@@ -2261,12 +2261,12 @@
     },
     "imei": {
       "caption": "IMEI",
-      "description": "The International Mobile Station Equipment Identifier that is associated with the device.",
+      "description": "The International Mobile Equipment Identity that is associated with the device.",
       "type": "string_t"
     },
     "imei_alts": {
       "caption": "Alternate IMEIs",
-      "description": "Alternate International Mobile Station Equipment Identifiers that are associated with the device, such as additional IMEIs for devices with more than one Subscriber Identity Module (SIM).",
+      "description": "Alternate International Mobile Equipment Identity values that are associated with the device, such as additional IMEIs for devices with more than one Subscriber Identity Module (SIM).",
       "is_array": true,
       "type": "string_t"
     },

--- a/dictionary.json
+++ b/dictionary.json
@@ -2262,11 +2262,15 @@
     "imei": {
       "caption": "IMEI",
       "description": "The International Mobile Equipment Identity that is associated with the device.",
-      "type": "string_t"
+      "type": "string_t",
+      "@deprecated": {
+        "message": "Use the <code>imeis</code> attribute instead.",
+        "since": "1.4.0"
+      }
     },
-    "imei_alts": {
-      "caption": "Alternate IMEIs",
-      "description": "Alternate International Mobile Equipment Identity values that are associated with the device, such as additional IMEIs for devices with more than one Subscriber Identity Module (SIM).",
+    "imeis": {
+      "caption": "IMEIs",
+      "description": "The International Mobile Equipment Identity values that are associated with the device.",
       "is_array": true,
       "type": "string_t"
     },

--- a/objects/device.json
+++ b/objects/device.json
@@ -46,6 +46,9 @@
     "imei": {
       "requirement": "optional"
     },
+    "imei_alts": {
+      "requirement": "optional"
+    },
     "ip": {
       "description": "The device IP address, in either IPv4 or IPv6 format.",
       "requirement": "optional"

--- a/objects/device.json
+++ b/objects/device.json
@@ -46,7 +46,7 @@
     "imei": {
       "requirement": "optional"
     },
-    "imei_alts": {
+    "imeis": {
       "requirement": "optional"
     },
     "ip": {


### PR DESCRIPTION
#### Related Issue: 
https://github.com/ocsf/ocsf-schema/issues/1211

#### Description of changes:

According to the [Wikipedia article for IMEI](https://en.wikipedia.org/wiki/International_Mobile_Equipment_Identity):

> Dual SIM enabled phones will have two IMEI numbers.

This change depreciates the existing `imei` attribute in the `device` object in favour of a new `imeis` array object. This accommodates additional IMEI values available in common dual-SIM and possible multi-SIM mobile devices.

<img width="1293" alt="Screenshot 2024-10-28 at 2 51 37 PM" src="https://github.com/user-attachments/assets/61d0c16e-012b-4558-ad6b-40a04ce1103c">


