### PR TITLE
Add BIOS Serial Number to Device Hardware Info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Thankyou! -->
     1. Added `unmanned_system_operator` to the dictionary, extends `user`. #1169
     1. Added `locations` to the dictionary, an array type of the `location` object, used within the new `operating_area` object. #1169
     1. Added `altitude_ceiling`, `altitude_floor`, `geodetic_altitude`, `aerial_height`, `horizontal_accuracy`, `pressure_altitude`, `radius`, `speed`, `track_direction`, and `vertical_speed` all to support `operating_area` and `unmanned_aerial_system` objects. #1169 
+    1. Added `bios_serial` as a `string_t`.
 * #### Objects
     1. Added `environment_variable` object. #1172
     1. Added `advisory` object. #1176
@@ -105,6 +106,7 @@ Thankyou! -->
     1. Added `control_parameters` and `status_details` to the compliance object. #1219
     1. Added `geodetic_altitude`, `height`, `horizontal_accuracy`, and `pressure_altitude` to `location`. #1169
     1. Added `location` to `managed_entity`. #1169
+    1. Added `bios_serial` to `device_hw_info`.
 
 ### Bugfixes
     1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180

--- a/dictionary.json
+++ b/dictionary.json
@@ -367,6 +367,11 @@
       "description": "The BIOS manufacturer. For example: <code>LENOVO</code>.",
       "type": "string_t"
     },
+    "bios_serial": {
+      "caption": "BIOS Serial Number",
+      "description": "The BIOS serial number. For example: <code>VMWare-56 4d 5e 58 fb 3b 85 30-87 8a 74 a9 6f a7 19 88</code>.",
+      "type": "string_t"
+    },
     "bios_ver": {
       "caption": "BIOS Version",
       "description": "The BIOS version. For example: <code>LENOVO G5ETA2WW (2.62)</code>.",

--- a/objects/device_hw_info.json
+++ b/objects/device_hw_info.json
@@ -13,6 +13,9 @@
     "bios_ver": {
       "requirement": "optional"
     },
+    "bios_serial": {
+      "requirement": "optional"
+    },
     "chassis": {
       "requirement": "optional"
     },


### PR DESCRIPTION
#### Related Issue: 

#### Description of changes:

This change adds an optional BIOS Serial Number field to the Device Hardware Object to help disambiguate when two or more devices report using the same device manufacturer serial number (`device_hardware_info.serial_number`). One practical use is disambiguating some virtual machines.

It can help but cannot disambiguate all cases. When a VMWare virtual machine is copied, the [BIOS Serial Number is changed](https://techhead.co/vmware-esx-i-moved-it-or-i-copied-it-whats-the-difference/). However, VirtualBox appears to assign [hardcoded values](https://www.virtualbox.org/manual/ch09.html#changedmi) so it would not be useful there.   