### PR TITLE
Clarify difference between Apple UDID and hardware UUID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@ Thankyou! -->
 
 ### Misc
 1. Updated description of `config_state` to reflect the addition of the `assessments` object. #1343
-
+1. Updated description of `hw_info.uuid` to clarify usage especially in presence of new `device.udid` field. #1354
 
 ## [v1.4.0] - January 31st, 2025
 

--- a/dictionary.json
+++ b/dictionary.json
@@ -5496,10 +5496,10 @@
       "type": "string_t",
       "is_array": true
     },
-    "udid": {
-      "caption": "Unique Device Identifier",
-      "description": "The Unique Device Identifier, used for iOS and macOS devices.",
-      "type": "string_t"
+    "apple_udid": {
+      "caption": "UDID",
+      "description": "The Apple assigned <a href='https://theapplewiki.com/wiki/UDID'>Unique Device Identifier</a> (UDID). It is the UDID for iOS, iPadOS, tvOS, watchOS, and visionOS devices. It is the Provisioning UDID in macOS devices.",
+      "type": "apple_udid_t"
     },
     "uid": {
       "caption": "Unique ID",
@@ -5746,6 +5746,13 @@
     "caption": "Data Types",
     "description": "The data types available in OCSF. Each data type specifies constraints in the form regular expressions, max lengths or value limits. Implementors of OCSF should ensure they abide to these constraints.",
     "attributes": {
+      "apple_udid_t": {
+        "caption": "Apple UDID",
+        "description": "Apple <a href='https://theapplewiki.com/wiki/UDID'>Unique Device Identifier</a>. For example:<br><code>9f9bb1b742882152fb1746aab7db415cea979232</code> in the legacy 40 characters format, <code>00008020-008D4548007B4F26</code> in the current 24+1 characters format",
+        "regex": "[0-9a-fA-F]{40}|[0-9a-fA-F]{8}-[0-9a-fA-F]{16}",
+        "type": "string_t",
+        "type_name": "String"
+      },
       "boolean_t": {
         "caption": "Boolean",
         "description": "Boolean value. One of <code>true</code> or <code>false</code>.",

--- a/dictionary.json
+++ b/dictionary.json
@@ -5496,10 +5496,10 @@
       "type": "string_t",
       "is_array": true
     },
-    "apple_udid": {
-      "caption": "UDID",
-      "description": "The Apple assigned <a href='https://theapplewiki.com/wiki/UDID'>Unique Device Identifier</a> (UDID). It is the UDID for iOS, iPadOS, tvOS, watchOS, and visionOS devices. It is the Provisioning UDID in macOS devices.",
-      "type": "apple_udid_t"
+    "udid": {
+      "caption": "Unique Device Identifier",
+      "description": "The Apple assigned <a href='https://theapplewiki.com/wiki/UDID'>Unique Device Identifier</a> (UDID). It is the UDID for iOS, iPadOS, tvOS, watchOS, and visionOS devices. It is the Provisioning UDID for macOS devices. For example: <code>00008020-008D4548007B4F26</code>",
+      "type": "string_t"
     },
     "uid": {
       "caption": "Unique ID",
@@ -5746,13 +5746,6 @@
     "caption": "Data Types",
     "description": "The data types available in OCSF. Each data type specifies constraints in the form regular expressions, max lengths or value limits. Implementors of OCSF should ensure they abide to these constraints.",
     "attributes": {
-      "apple_udid_t": {
-        "caption": "Apple UDID",
-        "description": "Apple <a href='https://theapplewiki.com/wiki/UDID'>Unique Device Identifier</a>. For example:<br><code>9f9bb1b742882152fb1746aab7db415cea979232</code> in the legacy 40 characters format, <code>00008020-008D4548007B4F26</code> in the current 24+1 characters format",
-        "regex": "[0-9a-fA-F]{40}|[0-9a-fA-F]{8}-[0-9a-fA-F]{16}",
-        "type": "string_t",
-        "type_name": "String"
-      },
       "boolean_t": {
         "caption": "Boolean",
         "description": "Boolean value. One of <code>true</code> or <code>false</code>.",

--- a/objects/device.json
+++ b/objects/device.json
@@ -140,6 +140,9 @@
       "description": "The device type ID.",
       "requirement": "required"
     },
+    "udid": {
+      "requirement": "optional"
+    },
     "uid": {
       "description": "The unique identifier of the device. For example the Windows TargetSID or AWS EC2 ARN.",
       "requirement": "recommended"

--- a/objects/device.json
+++ b/objects/device.json
@@ -140,9 +140,6 @@
       "description": "The device type ID.",
       "requirement": "required"
     },
-    "udid": {
-      "requirement": "optional"
-    },
     "uid": {
       "description": "The unique identifier of the device. For example the Windows TargetSID or AWS EC2 ARN.",
       "requirement": "recommended"

--- a/objects/device_hw_info.json
+++ b/objects/device_hw_info.json
@@ -50,11 +50,8 @@
       "description": "The device manufacturer serial number.",
       "requirement": "optional"
     },
-    "apple_udid": {
-      "requirement": "optional"
-    },
     "uuid": {
-      "description": "The device manufacturer assigned universally unique hardware identifier. It is the System UUID for <a href='https://www.dmtf.org/standards/smbios'>SMBIOS</a> compatible devices. It is the Hardware UUID (<code>IOPlatformUUID</code>) for macOS devices.",
+      "description": "The device manufacturer assigned universally unique hardware identifier. It is the System UUID for <a href='https://www.dmtf.org/standards/smbios'>SMBIOS</a> compatible devices such as those running Linux and Windows. It is the Hardware UUID (also known as <code>IOPlatformUUID</code>) for macOS devices.",
       "requirement": "optional"
     },
     "vendor_name": {

--- a/objects/device_hw_info.json
+++ b/objects/device_hw_info.json
@@ -50,8 +50,11 @@
       "description": "The device manufacturer serial number.",
       "requirement": "optional"
     },
+    "apple_udid": {
+      "requirement": "optional"
+    },
     "uuid": {
-      "description": "The device manufacturer assigned universally unique hardware identifier. For example: The BIOS System UUID or the Apple IOPlatformUUID.",
+      "description": "The device manufacturer assigned universally unique hardware identifier. It is the System UUID for <a href='https://www.dmtf.org/standards/smbios'>SMBIOS</a> compatible devices. It is the Hardware UUID (<code>IOPlatformUUID</code>) for macOS devices.",
       "requirement": "optional"
     },
     "vendor_name": {


### PR DESCRIPTION
#### Related Issue: 

#### Description of changes:

The OCSF 1.5 draft [recently introduced](https://github.com/ocsf/ocsf-schema/commit/e3efe4a87f002955ac978fa2fc2d96a4940174e5) a new `device.udid` field to store the Unique Device Identifier (UDID) for Apple devices. This proposed change adds more specific usage guidance and clarifies the difference between the new field and the existing `device.hw_info.uuid` field. The intent is to discourage misuse, such as incorrectly storing the Mac hardware UUID in the `udid` field while not populating `device.hw_info.uuid`, resulting in failure when joining data belonging to the same device.  

Before:

![image](https://github.com/user-attachments/assets/4edb8fde-9769-4177-939e-7645e223bac2)

![image](https://github.com/user-attachments/assets/3d199837-674a-4b9f-a02b-2934b1c4d3a1)

After:

![image](https://github.com/user-attachments/assets/a390d216-0f80-435b-be95-0060fcf41f26)

![image](https://github.com/user-attachments/assets/50ae5994-0f5a-4586-a5b2-e5fac48873ff)
