### PR TITLE
Clarify that hyphens may need to be added to Linux Machine ID to create a valid UUID

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -3808,7 +3808,7 @@
     },
     "os_machine_uuid": {
       "caption": "OS Machine UUID",
-      "description": "The operating system assigned Machine ID. In Windows, this is the value stored at the registry path: <code>HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Cryptography\\MachineGuid</code>. In Linux, this is stored in the file: <code>/etc/machine-id</code>.",
+      "description": "The operating system assigned Machine ID. In Windows, this is the value stored at the registry path: <code>HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Cryptography\\MachineGuid</code>. In Linux, this is stored in the file: <code>/etc/machine-id</code>. Add hyphens when necessary to create a valid UUID.",
       "type": "uuid_t"
     },
     "osint": {


### PR DESCRIPTION
#### Description of changes:

The Linux `/etc/machine-id` file stores the UUID as a string without hyphens. E.g.,

```

```

This change clarifies hyphens may need to be added to create a UUID for the `os_machine_uuid` field.

Before:

<img width="1445" alt="image" src="https://github.com/user-attachments/assets/635f0758-7efd-43ba-9aa0-059165b92cdf" />

After:

<img width="1441" alt="image" src="https://github.com/user-attachments/assets/f76a5cd1-0102-4b13-907d-406df60ab19a" />